### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ and then:
 
 `$ pip3 install --user meson`
 
+(or: `$ sudo apt install meson`)
+
+
 Finally, clone this repository:
 
 `$ git clone https://github.com/galantelab/sideRETRO.git`


### PR DESCRIPTION
The command "pip3 install --user meson" may require setting the environment variable. This one "sudo apt install meson" doesn't require it.